### PR TITLE
Create launch_agent_dir if it doesn't exist when loading agent

### DIFF
--- a/mv_dwnlds/plist.py
+++ b/mv_dwnlds/plist.py
@@ -1,5 +1,6 @@
 from os.path import dirname, abspath, join, exists
-from os import getcwd, system, remove, makedirs
+from os import getcwd, system, remove
+from pathlib import Path
 from plistlib import dump
 import argparse
 
@@ -33,6 +34,7 @@ def write_plist(plist_file_path, agent_name, python_env):
         KeepAlive=True
     )
     
+    Path(dirname(plist_file_path)).mkdir(parents=True, exist_ok=True)
     with open(plist_file_path, "wb") as fp:
         dump(plist, fp)
 


### PR DESCRIPTION
Bug fix for issue #5 

#### Changes
Using pathlib's Path to mkdir (as shown in this StackOverflow [post](https://stackoverflow.com/questions/273192/how-can-i-safely-create-a-nested-directory)) the `launch_agent_dir` if it doesn't exist before writing the plist file
